### PR TITLE
Fix contact form submission and upload progress

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
         acceptedFiles: '.stl,.obj,.3mf',
         uploadMultiple: true,
         parallelUploads: 10,
+        clickable: '.dz-message',
         autoProcessQueue: false,
       });
 
@@ -134,7 +135,7 @@
         }
       });
 
-      dz.on('totaluploadprogress', function (progress) {
+      dz.on('uploadprogress', function (file, progress) {
         if (progressBar) {
           progressBar.style.width = progress + '%';
         }


### PR DESCRIPTION
## Summary
- Restrict Dropzone clickable area to file dropzone to allow form submission
- Use upload progress event to update progress bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893411d7e20832eb7fabbbc0e28bbae