### PR TITLE
Replace Dropzone with free FilePond uploader

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,75 +83,26 @@
             background-size: 20px 20px;
         }
     </style>
-<!-- Dropzone.js -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/dropzone.min.css" rel="stylesheet"/>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/min/dropzone.min.js"></script>
+<!-- FilePond (Dropzone Alternative) -->
+<link href="https://unpkg.com/filepond@^4/dist/filepond.css" rel="stylesheet"/>
+<script src="https://unpkg.com/filepond@^4/dist/filepond.min.js"></script>
+<script src="https://unpkg.com/filepond-plugin-file-validate-type/dist/filepond-plugin-file-validate-type.min.js"></script>
+<script src="https://unpkg.com/filepond-plugin-file-validate-size/dist/filepond-plugin-file-validate-size.min.js"></script>
 <script>
-  Dropzone.autoDiscover = false;
+  FilePond.registerPlugin(
+    FilePondPluginFileValidateType,
+    FilePondPluginFileValidateSize
+  );
+
   window.addEventListener('DOMContentLoaded', function () {
-    const formElement = document.getElementById('contact-form');
-    if (formElement) {
-      const dz = new Dropzone(formElement, {
-        paramName: 'attachment',
-        maxFilesize: 50,
-        acceptedFiles: '.stl,.obj,.3mf',
-        uploadMultiple: true,
-        parallelUploads: 10,
-        clickable: '.dz-message',
-        autoProcessQueue: false,
-      });
-
-      function appendFormFields(formData) {
-        const fields = formElement.querySelectorAll('input:not([type=file]):not([type=submit]), select, textarea');
-        fields.forEach(field => {
-          formData.append(field.name, field.value);
-        });
-      }
-
-      formElement.addEventListener('submit', function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-        if (dz.getQueuedFiles().length > 0) {
-          dz.processQueue();
-        } else {
-          formElement.submit();
-        }
-      });
-
-      const progressWrapper = document.getElementById('upload-progress-wrapper');
-      const progressBar = document.getElementById('upload-progress');
-
-      dz.on('sending', function (file, xhr, formData) {
-        appendFormFields(formData);
-        if (progressWrapper) {
-          progressWrapper.classList.remove('hidden');
-        }
-      });
-
-      dz.on('sendingmultiple', function (files, xhr, formData) {
-        appendFormFields(formData);
-        if (progressWrapper) {
-          progressWrapper.classList.remove('hidden');
-        }
-      });
-
-      dz.on('uploadprogress', function (file, progress) {
-        if (progressBar) {
-          progressBar.style.width = progress + '%';
-        }
-      });
-
-      dz.on('queuecomplete', function () {
-        if (progressWrapper) {
-          progressWrapper.classList.add('hidden');
-          if (progressBar) {
-            progressBar.style.width = '0%';
-          }
-        }
-        const next = formElement.querySelector('input[name="_next"]').value;
-        if (next) {
-          window.location.href = next;
-        }
+    const inputElement = document.getElementById('attachments');
+    if (inputElement) {
+      FilePond.create(inputElement, {
+        allowMultiple: true,
+        maxFileSize: '50MB',
+        acceptedFileTypes: ['model/stl', 'model/obj', 'model/3mf'],
+        storeAsFile: true,
+        labelIdle: 'Drag & Drop Your Files or <span class="filepond--label-action">Browse</span><br/><small>Supported formats: STL, OBJ, 3MF (Max 50MB)</small>'
       });
     }
   });
@@ -622,7 +573,7 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
 <div class="md:w-1/2">
 <div class="bg-white rounded-xl shadow-md p-8">
 <h3 class="text-xl font-semibold mb-6">Send Us a Message</h3>
-<form id="contact-form" action="https://formsubmit.co/ecoprintinnovations@gmail.com" class="dropzone" enctype="multipart/form-data" method="POST">
+<form id="contact-form" action="https://formsubmit.co/ecoprintinnovations@gmail.com" enctype="multipart/form-data" method="POST">
     <input type="hidden" name="_subject" value="New 3D File Upload from Eco Print Innovations!"/>
     <input type="hidden" name="_captcha" value="false"/>
     <input type="hidden" name="_next" value="https://ecoprintinnovations.github.io/ecoprintinnovations.co.uk/thankyou.html"/>
@@ -670,15 +621,7 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
 <textarea class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500" id="message" name="message" rows="4"></textarea>
 </div>
     <div class="mb-4">
-      <div class="dz-message flex flex-col items-center justify-center p-6 border-2 border-dashed border-green-500 rounded-lg bg-green-50" data-dz-message>
-        <img src="https://img.icons8.com/fluency/48/upload.png" alt="Upload icon"/>
-        <h3 class="text-lg font-semibold mt-2">Drag & Drop Your Files Here (Optional)</h3>
-        <p>or click to browse your files</p>
-        <small>Supported formats: STL, OBJ, 3MF (Max 50MB)</small>
-      </div>
-      <div id="upload-progress-wrapper" class="w-full bg-gray-200 rounded-full h-2 mt-4 hidden">
-        <div id="upload-progress" class="bg-green-600 h-2 rounded-full" style="width: 0%"></div>
-      </div>
+      <input type="file" id="attachments" name="attachment" multiple />
     </div>
 <button class="w-full bg-green-600 text-white py-3 rounded-lg font-semibold hover:bg-green-700 transition duration-300" type="submit">
                                 Send Message
@@ -749,7 +692,7 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
 </div>
 </div>
 </footer>
-<!-- Dropzone Upload -->
+<!-- File Upload -->
 <!-- Contact Form -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- swap Dropzone.js for FilePond, a free drag-and-drop uploader
- simplify contact form to use FilePond-managed file input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689346e6f494832e95d5f9693578f00a