### PR TITLE
feat: add consent banner and conditional analytics

### DIFF
--- a/consent.js
+++ b/consent.js
@@ -1,0 +1,78 @@
+(function() {
+  const consentScript = document.currentScript;
+
+  function loadGA(gaId) {
+    if (window.gaLoaded || !gaId) return;
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    window.gtag = window.gtag || gtag;
+    const s = document.createElement('script');
+    s.async = true;
+    s.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;
+    document.head.appendChild(s);
+    gtag('js', new Date());
+    gtag('config', gaId);
+    window.gaLoaded = true;
+  }
+
+  function loadFB(pixelId) {
+    if (window.fbq || !pixelId) return;
+    !(function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)})(window,
+    document,'script','https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', pixelId);
+    fbq('track', 'PageView');
+  }
+
+  function enableAnalytics() {
+    if (window.analyticsEnabled) return;
+    window.analyticsEnabled = true;
+    const gaId = consentScript.dataset.gaId || window.GA_MEASUREMENT_ID;
+    const pixelId = consentScript.dataset.pixelId || window.FB_PIXEL_ID;
+    if (gaId) loadGA(gaId);
+    if (pixelId) loadFB(pixelId);
+  }
+
+  function showBanner() {
+    const banner = document.createElement('div');
+    banner.id = 'consent-banner';
+    banner.innerHTML = `
+      <span>We use cookies for analytics.</span>
+      <div>
+        <button id="consent-accept">Accept</button>
+        <button id="consent-decline">Decline</button>
+      </div>`;
+
+    const style = document.createElement('style');
+    style.textContent = `
+      #consent-banner{position:fixed;bottom:0;left:0;right:0;background:#1f2937;color:#fff;padding:0.75rem;font-size:0.875rem;display:flex;justify-content:space-between;align-items:center;z-index:1000;}
+      #consent-banner button{margin-left:0.5rem;padding:0.25rem 0.75rem;border:none;border-radius:0.25rem;cursor:pointer;}
+      #consent-accept{background:#16a34a;color:#fff;}
+      #consent-decline{background:#6b7280;color:#fff;}
+    `;
+    document.head.appendChild(style);
+    document.body.appendChild(banner);
+
+    document.getElementById('consent-accept').addEventListener('click', function(){
+      localStorage.setItem('cookieConsent', 'granted');
+      banner.remove();
+      enableAnalytics();
+    });
+
+    document.getElementById('consent-decline').addEventListener('click', function(){
+      localStorage.setItem('cookieConsent', 'denied');
+      banner.remove();
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    const consent = localStorage.getItem('cookieConsent');
+    if (consent === 'granted') {
+      enableAnalytics();
+    } else if (consent !== 'denied') {
+      showBanner();
+    }
+  });
+})();

--- a/contact.html
+++ b/contact.html
@@ -285,6 +285,23 @@
     }
   });
 </script>
+<!-- Facebook Pixel (disabled by default)
+     To enable, set a pixel ID via data-pixel-id on consent.js script tag
+     or define FB_PIXEL_ID in the environment. Uncomment the code below to
+     include the standard snippet manually.
+-->
+<!--
+<script>
+  !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+  n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+  document,'script','https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', 'YOUR_PIXEL_ID');
+  fbq('track', 'PageView');
+</script>
+-->
+<script src="/consent.js" data-ga-id="" data-pixel-id=""></script>
 </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -673,5 +673,22 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
 </div>
 </div>
 </footer>
+<!-- Facebook Pixel (disabled by default)
+     To enable, set a pixel ID via data-pixel-id on consent.js script tag
+     or define FB_PIXEL_ID in the environment. Uncomment the code below to
+     include the standard snippet manually.
+-->
+<!--
+<script>
+  !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+  n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+  document,'script','https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', 'YOUR_PIXEL_ID');
+  fbq('track', 'PageView');
+</script>
+-->
+<script src="/consent.js" data-ga-id="" data-pixel-id=""></script>
 </body>
 </html>

--- a/thankyou.html
+++ b/thankyou.html
@@ -23,5 +23,22 @@
       }
     });
   </script>
+<!-- Facebook Pixel (disabled by default)
+     To enable, set a pixel ID via data-pixel-id on consent.js script tag
+     or define FB_PIXEL_ID in the environment. Uncomment the code below to
+     include the standard snippet manually.
+-->
+<!--
+<script>
+  !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+  n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+  document,'script','https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', 'YOUR_PIXEL_ID');
+  fbq('track', 'PageView');
+</script>
+-->
+<script src="/consent.js" data-ga-id="" data-pixel-id=""></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add script that displays a consent banner and stores user choice in localStorage
- load GA4 and optional Facebook Pixel only after consent is granted
- include commented Facebook Pixel snippet with instructions on enabling via attributes or environment variables

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a136684b8832e8dda7b635719a447