### PR TITLE
Hide email address in contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -94,15 +94,6 @@
 </div>
 <div class="flex items-start">
 <div class="bg-green-100 p-3 rounded-full mr-4">
-<i class="fas fa-envelope text-green-600"></i>
-</div>
-<div>
-<h4 class="font-semibold">Email Us</h4>
-<p class="text-gray-600"><a id="email-link"></a></p>
-</div>
-</div>
-<div class="flex items-start">
-<div class="bg-green-100 p-3 rounded-full mr-4">
 <i class="fas fa-phone text-green-600"></i>
 </div>
 <div>
@@ -143,7 +134,7 @@
 <div class="md:w-1/2">
 <div class="bg-white rounded-xl shadow-md p-8">
 <h3 class="text-xl font-semibold mb-6">Send Us a Message</h3>
-<form id="contact-form" action="https://formsubmit.co/ecoprintinnovations@gmail.com" enctype="multipart/form-data" method="POST">
+<form id="contact-form" action="https://formsubmit.co/6b0307e459ac40629033316b50f67f89" enctype="multipart/form-data" method="POST">
 <input type="hidden" name="_subject" value="New 3D File Upload from Eco Print Innovations"/>
 <input type="hidden" name="_captcha" value="false"/>
 <input type="hidden" name="_next" value="https://ecoprintinnovations.github.io/ecoprintinnovations.co.uk/thankyou.html"/>
@@ -154,7 +145,7 @@
 </div>
 <div class="mb-4">
 <label class="block text-gray-700 mb-2" for="email">Email Address</label>
-<input class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500" id="email" name="email" type="email"/>
+<input class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500" id="email" name="_replyto" type="email"/>
 </div>
 <div class="mb-4">
 <label class="block text-gray-700 mb-2" for="phone">Phone Number</label>
@@ -274,14 +265,6 @@
     if (nextField) {
       const base = nextField.value.split('?')[0];
       nextField.value = `${base}?request_id=${encodeURIComponent(id)}`;
-    }
-    const user = 'ecoprintinnovations';
-    const domain = 'gmail.com';
-    const emailLink = document.getElementById('email-link');
-    if (emailLink) {
-      const email = `${user}@${domain}`;
-      emailLink.href = `mailto:${email}`;
-      emailLink.textContent = email;
     }
   });
 </script>


### PR DESCRIPTION
## Summary
- use a FormSubmit alias for the contact form action and send reply-to via `_replyto`
- remove direct email display and script so address isn't exposed in HTML

## Testing
- `npx htmlhint contact.html` *(fails: 403 Forbidden from npm registry)*
- `rg -i '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'`


------
https://chatgpt.com/codex/tasks/task_e_689a668fa3c0832e84b87dfc35cac036