### PR TITLE
Replace outdated links with in-page anchors

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -216,9 +216,9 @@
 <h4 class="text-lg font-semibold mb-4">Quick Links</h4>
 <ul class="space-y-2">
 <li><a class="text-gray-400 hover:text-white transition" href="/index.html">Home</a></li>
-<li><a class="text-gray-400 hover:text-white transition" href="/services.html">Services</a></li>
-<li><a class="text-gray-400 hover:text-white transition" href="/materials.html">Materials</a></li>
-<li><a class="text-gray-400 hover:text-white transition" href="/about.html">About Us</a></li>
+<li><a class="text-gray-400 hover:text-white transition" href="/#services">Services</a></li>
+<li><a class="text-gray-400 hover:text-white transition" href="/#materials">Materials</a></li>
+<li><a class="text-gray-400 hover:text-white transition" href="/#about">About Us</a></li>
 <li><a class="text-gray-400 hover:text-white transition" href="/contact.html">Contact</a></li>
 </ul>
 </div>
@@ -246,10 +246,9 @@
 <div class="border-t border-gray-700 mt-12 pt-8 text-center text-gray-400">
 <p>© 2025 Eco Print Innovations. All rights reserved.</p>
 <nav class="mt-2 flex justify-center space-x-4">
-<a class="hover:text-white transition" href="/about.html">About</a>
-<a class="hover:text-white transition" href="/services.html">Services</a>
-<a class="hover:text-white transition" href="/materials.html">Materials</a>
-<a class="hover:text-white transition" href="/portfolio.html">Portfolio</a>
+<a class="hover:text-white transition" href="/#about">About</a>
+<a class="hover:text-white transition" href="/#services">Services</a>
+<a class="hover:text-white transition" href="/#materials">Materials</a>
 <a class="hover:text-white transition" href="/contact.html">Contact</a>
 </nav>
 <div class="mt-2 flex justify-center space-x-4">

--- a/index.html
+++ b/index.html
@@ -192,10 +192,10 @@
 <span class="text-sm font-semibold">Sustainable 3D Printing</span>
 </div>
 <h1 class="text-4xl md:text-5xl font-bold mb-4">Where Sustainability Meets Precision</h1>
-<p class="text-xl mb-8">3D Printing, Design, Repairs &amp; Training – All with an Eco-First Approach. Learn more <a href="/about.html" class="underline">about us</a>.</p>
+<p class="text-xl mb-8">3D Printing, Design, Repairs &amp; Training – All with an Eco-First Approach. Learn more <a href="#about" class="underline">about us</a>.</p>
 <div class="flex flex-col sm:flex-row space-y-3 sm:space-y-0 sm:space-x-4">
 <a class="bg-white text-green-600 px-6 py-3 rounded-lg font-semibold text-center hover:bg-gray-100 transition duration-300 transform hover:scale-105" href="/contact.html">Upload Your File for a Free Quote</a>
-<a class="border-2 border-white px-6 py-3 rounded-lg font-semibold text-center hover:bg-white hover:text-green-600 transition duration-300 transform hover:scale-105" href="/services.html">Our Services</a>
+<a class="border-2 border-white px-6 py-3 rounded-lg font-semibold text-center hover:bg-white hover:text-green-600 transition duration-300 transform hover:scale-105" href="#services">Our Services</a>
 </div>
 <div class="mt-8 flex items-center space-x-4">
 <!-- Client Images Stack -->
@@ -213,7 +213,7 @@
 <i class="fas fa-star text-yellow-300 mr-1"></i>
 <i class="fas fa-star text-yellow-300 mr-1"></i>
 </div>
-<p class="text-sm">Trusted by 1000+ clients—see our <a href="/portfolio.html" class="underline">portfolio</a>.</p>
+<p class="text-sm">Trusted by 1000+ clients.</p>
 </div>
 </div>
 </div>
@@ -384,7 +384,7 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
 <div class="container mx-auto px-4">
 <div class="text-center mb-12">
 <h2 class="text-3xl font-bold mb-4">Our Sustainable Materials</h2>
-<p class="text-lg text-gray-600 max-w-2xl mx-auto">Environmentally friendly materials that don't compromise on quality. Explore the full range on our <a href="/materials.html" class="text-green-600 hover:underline">materials page</a>.</p>
+<p class="text-lg text-gray-600 max-w-2xl mx-auto">Environmentally friendly materials that don't compromise on quality. Explore the full range below.</p>
 </div>
 <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
 <!-- Material 1 -->
@@ -469,7 +469,7 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
 <div class="w-full mb-10">
 <h2 class="text-3xl font-bold mb-6">Our Commitment to Sustainability</h2>
 <p class="text-gray-600 mb-6">At Eco Print Innovations, we’re not just focused on high quality prints we’re building a business that puts the planet first. From how we power our workspace to how we package and ship our products, sustainability shapes every part of what we do.</p>
-<p class="text-gray-600 mb-6">Learn more about our values on the <a href="/about.html" class="text-green-600 hover:underline">About page</a>.</p>
+<p class="text-gray-600 mb-6">Learn more about our values.</p>
 <div class="space-y-4">
 <div class="flex items-start">
 <div class="bg-green-100 p-2 rounded-full mr-4 mt-1">
@@ -654,11 +654,10 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
 <div class="border-t border-gray-700 mt-12 pt-8 text-center text-gray-400">
 <p>© 2025 Eco Print Innovations. All rights reserved.</p>
 <nav class="mt-2 flex justify-center space-x-4">
-<a class="hover:text-white transition" href="/about.html">About</a>
-<a class="hover:text-white transition" href="/services.html">Services</a>
-<a class="hover:text-white transition" href="/materials.html">Materials</a>
-<a class="hover:text-white transition" href="/portfolio.html">Portfolio</a>
-<a class="hover:text-white transition" href="/contact.html">Contact</a>
+<a class="hover:text-white transition" href="#about">About</a>
+<a class="hover:text-white transition" href="#services">Services</a>
+<a class="hover:text-white transition" href="#materials">Materials</a>
+<a class="hover:text-white transition" href="#contact">Contact</a>
 </nav>
 <div class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="#">Privacy Policy</a>


### PR DESCRIPTION
## Summary
- switch hero links to internal `#about` and `#services` anchors
- drop references to nonexistent portfolio page
- convert footer navigation across pages to in-page anchors or existing paths

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b2cb6444c832e91ffc8644e3c4692