### PR TITLE
Remove outdated metadata from privacy policy

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -72,12 +72,6 @@
 <main class="py-16 bg-gray-50">
   <div class="container mx-auto px-4">
     <h1 class="text-3xl font-bold mb-4">Eco Print Innovations – Privacy Policy</h1>
-    <p><strong>Document Ref:</strong> EPI-PP-002-V1.0</p>
-    <p><strong>Date Issued:</strong> 07/08/2025</p>
-    <p><strong>Author:</strong> Oliver Green – Sustainability & Compliance Advisor</p>
-    <p><strong>Approved by:</strong> Board (pending)</p>
-    <p><strong>Next Review:</strong> 07/08/2026</p>
-    <p><strong>Status:</strong> Active</p>
 
     <h2 class="text-2xl font-bold mt-8 mb-4">1. Introduction</h2>
     <p>This Privacy Policy explains how Eco Print Innovations Ltd (“we”, “us”, “our”) collects, uses, and protects your personal information when you visit or make a purchase from ecoprintinnovations.co.uk (the “Site”), or when you interact with us through other sales channels including eBay, Etsy, TikTok Shop, and direct B2B enquiries.</p>


### PR DESCRIPTION
## Summary
- remove document reference metadata lines from privacy policy
- keep spacing and heading for introduction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c97240994832ebb664a2f3c55658b