### PR TITLE
Add refund and returns policy page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -51,6 +51,7 @@
     </nav>
 <div class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/privacy-policy.html">Privacy Policy</a>
+    <a class="hover:text-white transition" href="/refund-and-returns-policy.html">Refund & Returns Policy</a>
 <a class="hover:text-white transition" href="#">Terms of Service</a>
 <a class="hover:text-white transition" href="#">Sustainability Policy</a>
 </div>
@@ -259,6 +260,7 @@
 </nav>
 <div class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/privacy-policy.html">Privacy Policy</a>
+    <a class="hover:text-white transition" href="/refund-and-returns-policy.html">Refund & Returns Policy</a>
 <a class="hover:text-white transition" href="#">Terms of Service</a>
 <a class="hover:text-white transition" href="#">Sustainability Policy</a>
 </div>

--- a/index.html
+++ b/index.html
@@ -664,6 +664,7 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
 </nav>
 <div class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/privacy-policy.html">Privacy Policy</a>
+    <a class="hover:text-white transition" href="/refund-and-returns-policy.html">Refund & Returns Policy</a>
 <a class="hover:text-white transition" href="#">Terms of Service</a>
 <a class="hover:text-white transition" href="#">Sustainability Policy</a>
 </div>

--- a/refund-and-returns-policy.html
+++ b/refund-and-returns-policy.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Privacy Policy - Eco Print Innovations</title>
+  <title>Refund and Returns Policy - Eco Print Innovations</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Lato:wght@300;400;700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet"/>
@@ -71,116 +71,22 @@
 </header>
 <main class="py-16 bg-gray-50">
   <div class="container mx-auto px-4">
-    <h1 class="text-3xl font-bold mb-4">Eco Print Innovations – Privacy Policy</h1>
+    <h1 class="text-3xl font-bold mb-4">Eco Print Innovations – Refund and Returns Policy</h1>
 
-    <h2 class="text-2xl font-bold mt-8 mb-4">1. Introduction</h2>
-    <p>This Privacy Policy explains how Eco Print Innovations Ltd (“we”, “us”, “our”) collects, uses, and protects your personal information when you visit or make a purchase from ecoprintinnovations.co.uk (the “Site”), or when you interact with us through other sales channels including eBay, Etsy, TikTok Shop, and direct B2B enquiries.</p>
-    <p>We are committed to safeguarding your privacy and ensuring your personal data is processed in line with the UK General Data Protection Regulation (UK GDPR) and the Data Use & Access Act 2025.</p>
+    <h2 class="text-2xl font-bold mt-8 mb-4">How Returns &amp; Refunds Work</h2>
+    <p>We don't currently sell products directly through this website. All purchases are handled through our official eBay, Etsy, and TikTok Shop stores.</p>
+    <p>Because of this, each platform's own returns and refunds policies apply to any order you place. These policies meet or exceed UK consumer law and explain your rights, timelines, and how to return an item.</p>
 
-    <h2 class="text-2xl font-bold mt-8 mb-4">2. Information We Collect</h2>
-    <h3 class="text-xl font-semibold mt-6 mb-2">Device Information</h3>
+    <h2 class="text-2xl font-bold mt-8 mb-4">Where to Find Our Policies</h2>
     <ul class="list-disc list-inside space-y-1">
-      <li><strong>Examples:</strong> Browser type/version, IP address, time zone, cookie identifiers, pages visited, search terms.</li>
-      <li><strong>Purpose:</strong> To load the Site correctly for you, improve user experience, and analyse site traffic.</li>
-      <li><strong>Source:</strong> Automatically collected via cookies, log files, and analytics tools.</li>
-      <li><strong>Disclosure:</strong> Shared with Shopify (website host) and analytics providers (e.g., Google Analytics, if enabled).</li>
-    </ul>
-    <h3 class="text-xl font-semibold mt-6 mb-2">Order Information</h3>
-    <ul class="list-disc list-inside space-y-1">
-      <li><strong>Examples:</strong> Name, billing/shipping address, payment details (processed via third-party gateways), email address, phone number.</li>
-      <li><strong>Purpose:</strong> To fulfil your orders, process payments, arrange delivery, send order confirmations, and provide customer support.</li>
-      <li><strong>Source:</strong> Collected directly from you.</li>
-      <li><strong>Disclosure:</strong> Shared with Shopify (store platform), payment processors (e.g., Stripe, PayPal), delivery partners (e.g., Royal Mail, couriers), sales channels (e.g., Etsy, eBay, TikTok Shop).</li>
-    </ul>
-    <h3 class="text-xl font-semibold mt-6 mb-2">Customer Support Information</h3>
-    <ul class="list-disc list-inside space-y-1">
-      <li><strong>Examples:</strong> Email correspondence, chat transcripts, complaint records.</li>
-      <li><strong>Purpose:</strong> To provide assistance and resolve issues.</li>
-      <li><strong>Source:</strong> Collected directly from you.</li>
-      <li><strong>Disclosure:</strong> Only shared internally or with service providers necessary to resolve your query.</li>
+      <li><a href="#" class="text-green-600 hover:underline">eBay – View our eBay shop returns policy</a></li>
+      <li><a href="#" class="text-green-600 hover:underline">Etsy – View our Etsy shop returns policy</a></li>
+      <li><a href="#" class="text-green-600 hover:underline">TikTok Shop – View our TikTok Shop returns policy</a></li>
     </ul>
 
-    <h2 class="text-2xl font-bold mt-8 mb-4">3. Minors</h2>
-    <p>Our Site is not intended for individuals under the age of 18. We do not knowingly collect personal information from children.</p>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">4. Sharing Your Personal Information</h2>
-    <p>We share your information with trusted service providers to operate our business and fulfil our contract with you. This may include:</p>
-    <ul class="list-disc list-inside space-y-1">
-      <li>Shopify – hosting and order management (Shopify Privacy Policy)</li>
-      <li>Payment processors – secure payment handling</li>
-      <li>Delivery companies – shipping orders to you</li>
-      <li>Marketing and analytics providers – only if you consent to cookies or marketing communications.</li>
-    </ul>
-    <p>We may also share your information to comply with legal obligations or respond to lawful requests.</p>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">5. Behavioural Advertising</h2>
-    <p>If you consent, we may use your information to send targeted marketing or show personalised ads. You can opt out at any time:</p>
-    <ul class="list-disc list-inside space-y-1">
-      <li>Email marketing: Use the unsubscribe link in any email.</li>
-      <li>Cookies/ads: Adjust your browser settings or visit Google Ads Settings and Facebook Ad Preferences.</li>
-    </ul>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">6. Using Your Personal Information</h2>
-    <p>We use your personal information to:</p>
-    <ul class="list-disc list-inside space-y-1">
-      <li>Offer products for sale</li>
-      <li>Process payments securely</li>
-      <li>Ship and fulfil orders</li>
-      <li>Communicate about orders or queries</li>
-      <li>Send offers and updates (if you’ve consented)</li>
-    </ul>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">7. Lawful Basis for Processing (UK GDPR)</h2>
-    <p>We process your personal data under:</p>
-    <ul class="list-disc list-inside space-y-1">
-      <li>Contract: To fulfil an order you placed with us.</li>
-      <li>Consent: For optional marketing or analytics cookies.</li>
-      <li>Legal obligation: To keep tax and transaction records.</li>
-      <li>Legitimate interests: To improve our services and prevent fraud.</li>
-    </ul>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">8. Retention</h2>
-    <p>We retain your personal data for as long as needed for the purposes outlined in this policy, unless you request deletion. For example:</p>
-    <ul class="list-disc list-inside space-y-1">
-      <li>Order records: 6 years (HMRC requirement)</li>
-      <li>Marketing contact data: until you opt out.</li>
-    </ul>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">9. Automated Decision-Making</h2>
-    <p>We do not carry out fully automated decision-making that has a legal or significant effect on you. Our payment processors and Shopify may use limited automated tools to prevent fraud.</p>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">10. Your Rights</h2>
-    <p>You have the right to:</p>
-    <ul class="list-disc list-inside space-y-1">
-      <li>Access the data we hold about you</li>
-      <li>Request correction or deletion</li>
-      <li>Restrict or object to processing</li>
-      <li>Data portability</li>
-    </ul>
-    <p>To exercise these rights, contact us at [Insert Contact Email].</p>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">11. Cookies</h2>
-    <p>We use cookies for:</p>
-    <ul class="list-disc list-inside space-y-1">
-      <li>Site functionality</li>
-      <li>Analytics (if consented)</li>
-      <li>Marketing (if consented)</li>
-    </ul>
-    <p>You can control cookies via your browser settings. More details are in our Cookie Policy.</p>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">12. Do Not Track</h2>
-    <p>We do not alter our data practices in response to “Do Not Track” signals.</p>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">13. Changes</h2>
-    <p>We may update this Privacy Policy to reflect changes in our practices or for legal reasons. Updates will be posted on this page with a revised date.</p>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">14. Contact</h2>
-    <p>If you have any questions or complaints about this policy, contact us:</p>
-    <ul class="list-disc list-inside space-y-1">
-      <li>Email: [Insert Email]</li>
-      <li>Post: Eco Print Innovations Ltd, Beechcroft, Waterloo Lane, Frodsham, England, WA6 6JN</li>
-    </ul>
-    <p>You can also lodge a complaint with the UK Information Commissioner’s Office: <a class="text-green-600 hover:underline" href="https://ico.org.uk/make-a-complaint/">https://ico.org.uk/make-a-complaint/</a></p>
+    <h2 class="text-2xl font-bold mt-8 mb-4">Questions or Support</h2>
+    <p>If you have any questions about a return or refund, the fastest way is to contact us through the platform where you made your purchase — this ensures your request is logged and processed correctly.</p>
+    <p>If you still need help, you can reach us via our <a href="/contact.html" class="text-green-600 hover:underline">Contact page</a> and we'll be happy to assist.</p>
   </div>
 </main>
 <footer class="bg-gray-800 text-white py-12">


### PR DESCRIPTION
## Summary
- Add dedicated Refund and Returns Policy page outlining platform-specific policies and support contact
- Link new policy from footers across the site for easy access

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689df5c21e3c832ea4672596eebbcd19