### PR TITLE
Add Shipping Policy footer link across pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -52,6 +52,7 @@
 <div class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/privacy-policy.html">Privacy Policy</a>
     <a class="hover:text-white transition" href="/refund-and-returns-policy.html">Refund & Returns Policy</a>
+    <a class="hover:text-white transition" href="/shipping-policy.html">Shipping Policy</a>
 <a class="hover:text-white transition" href="#">Terms of Service</a>
 <a class="hover:text-white transition" href="#">Sustainability Policy</a>
 </div>
@@ -261,6 +262,7 @@
 <div class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/privacy-policy.html">Privacy Policy</a>
     <a class="hover:text-white transition" href="/refund-and-returns-policy.html">Refund & Returns Policy</a>
+    <a class="hover:text-white transition" href="/shipping-policy.html">Shipping Policy</a>
 <a class="hover:text-white transition" href="#">Terms of Service</a>
 <a class="hover:text-white transition" href="#">Sustainability Policy</a>
 </div>

--- a/index.html
+++ b/index.html
@@ -665,6 +665,7 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
 <div class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/privacy-policy.html">Privacy Policy</a>
     <a class="hover:text-white transition" href="/refund-and-returns-policy.html">Refund & Returns Policy</a>
+    <a class="hover:text-white transition" href="/shipping-policy.html">Shipping Policy</a>
 <a class="hover:text-white transition" href="#">Terms of Service</a>
 <a class="hover:text-white transition" href="#">Sustainability Policy</a>
 </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -241,6 +241,7 @@
 <div class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/privacy-policy.html">Privacy Policy</a>
     <a class="hover:text-white transition" href="/refund-and-returns-policy.html">Refund & Returns Policy</a>
+    <a class="hover:text-white transition" href="/shipping-policy.html">Shipping Policy</a>
 <a class="hover:text-white transition" href="#">Terms of Service</a>
 <a class="hover:text-white transition" href="#">Sustainability Policy</a>
 </div>

--- a/refund-and-returns-policy.html
+++ b/refund-and-returns-policy.html
@@ -147,6 +147,7 @@
 <div class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/privacy-policy.html">Privacy Policy</a>
     <a class="hover:text-white transition" href="/refund-and-returns-policy.html">Refund & Returns Policy</a>
+    <a class="hover:text-white transition" href="/shipping-policy.html">Shipping Policy</a>
 <a class="hover:text-white transition" href="#">Terms of Service</a>
 <a class="hover:text-white transition" href="#">Sustainability Policy</a>
 </div>


### PR DESCRIPTION
## Summary
- Include Shipping Policy link in footer policy section on index, contact, privacy, and refund pages.
- Ensure policy links maintain consistent spacing and ordering across the site.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e124bfda8832eb757ad26c62d945c