### PR TITLE
Add company identity block to footer

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -253,6 +253,7 @@
 </div>
 <div class="border-t border-gray-700 mt-12 pt-8 text-center text-gray-400">
 <p>© 2025 Eco Print Innovations. All rights reserved.</p>
+<p class="mt-2">Eco Print Innovations Ltd · Registered in England & Wales No. 15798980 · Registered Office: Beechcroft, Water</p>
 <nav class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/#about">About</a>
 <a class="hover:text-white transition" href="/#services">Services</a>

--- a/index.html
+++ b/index.html
@@ -656,6 +656,7 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
 </div>
 <div class="border-t border-gray-700 mt-12 pt-8 text-center text-gray-400">
 <p>© 2025 Eco Print Innovations. All rights reserved.</p>
+<p class="mt-2">Eco Print Innovations Ltd · Registered in England & Wales No. 15798980 · Registered Office: Beechcroft, Water</p>
 <nav class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="#about">About</a>
 <a class="hover:text-white transition" href="#services">Services</a>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -232,6 +232,7 @@
 </div>
 <div class="border-t border-gray-700 mt-12 pt-8 text-center text-gray-400">
 <p>© 2025 Eco Print Innovations. All rights reserved.</p>
+<p class="mt-2">Eco Print Innovations Ltd · Registered in England & Wales No. 15798980 · Registered Office: Beechcroft, Water</p>
 <nav class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/#about">About</a>
 <a class="hover:text-white transition" href="/#services">Services</a>

--- a/refund-and-returns-policy.html
+++ b/refund-and-returns-policy.html
@@ -138,6 +138,7 @@
 </div>
 <div class="border-t border-gray-700 mt-12 pt-8 text-center text-gray-400">
 <p>© 2025 Eco Print Innovations. All rights reserved.</p>
+<p class="mt-2">Eco Print Innovations Ltd · Registered in England & Wales No. 15798980 · Registered Office: Beechcroft, Water</p>
 <nav class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/#about">About</a>
 <a class="hover:text-white transition" href="/#services">Services</a>

--- a/shipping-policy.html
+++ b/shipping-policy.html
@@ -138,6 +138,7 @@
 </div>
 <div class="border-t border-gray-700 mt-12 pt-8 text-center text-gray-400">
 <p>© 2025 Eco Print Innovations. All rights reserved.</p>
+<p class="mt-2">Eco Print Innovations Ltd · Registered in England & Wales No. 15798980 · Registered Office: Beechcroft, Water</p>
 <nav class="mt-2 flex justify-center space-x-4">
 <a class="hover:text-white transition" href="/#about">About</a>
 <a class="hover:text-white transition" href="/#services">Services</a>


### PR DESCRIPTION
## Summary
- add legally required company identity details to the global footer across site pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e1ab83a08832eaf30d6d81f7bd844