### PR TITLE
fix: restore FormSubmit token for contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -140,7 +140,7 @@
 <div class="md:w-1/2">
 <div class="bg-white rounded-xl shadow-md p-8">
 <h3 class="text-xl font-semibold mb-6">Send Us a Message</h3>
-<form id="contact-form" action="https://formsubmit.co/your@email.com" enctype="multipart/form-data" method="POST">
+<form id="contact-form" action="https://formsubmit.co/6b0307e459ac40629033316b50f67f89" enctype="multipart/form-data" method="POST">
 <input type="hidden" name="_subject" value="New 3D File Upload from Eco Print Innovations"/>
 <input type="hidden" name="_captcha" value="false"/>
 <input type="hidden" name="_next" value="https://ecoprintinnovations.github.io/ecoprintinnovations.co.uk/thankyou.html"/>


### PR DESCRIPTION
## Summary
- restore FormSubmit token in contact form action

## Testing
- `npx htmlhint contact.html` *(fails: 403 Forbidden from npm registry)*
- `npm test` *(fails: missing package.json)*
- `curl -L -X POST -F 'name=Test User' -F 'email=test@example.com' -F 'message=This is a test message' https://formsubmit.co/6b0307e459ac40629033316b50f67f89` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6056ca674832eaca3ecf6ff5fd60f