### PR TITLE
fix: adjust anchor scroll offset for sticky header

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,14 @@
             font-family: 'Poppins', sans-serif;
             scroll-behavior: smooth;
         }
+
+        :root {
+            --header-height: 8.25rem;
+        }
+
+        section[id] {
+            scroll-margin-top: calc(var(--header-height) + 1rem);
+        }
         .hero-gradient {
             background: linear-gradient(135deg, rgba(40, 180, 99, 0.9) 0%, rgba(33, 150, 83, 0.9) 100%);
         }
@@ -691,6 +699,16 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
   fbq('track', 'PageView');
 </script>
 -->
+<script>
+    function updateHeaderOffset() {
+        const header = document.querySelector('header');
+        if (header) {
+            document.documentElement.style.setProperty('--header-height', header.offsetHeight + 'px');
+        }
+    }
+    window.addEventListener('load', updateHeaderOffset);
+    window.addEventListener('resize', updateHeaderOffset);
+</script>
 <script src="/consent.js" data-ga-id="" data-pixel-id=""></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add CSS variable and scroll margin to offset anchor targets from sticky header
- dynamically update scroll offset based on header height

## Testing
- `npm test` *(fails: Could not read package.json)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a62ea791c8832e931234a5e49396fd