### PR TITLE
Revamp sustainability section layout and visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,69 +474,84 @@ Keep your machines running longer, cut downtime, and reduce waste  whether it’
 </div>
 </div>
 </section>
-<section class="py-16 bg-white" id="about">
-<div class="container mx-auto px-4">
-<div class="flex flex-col md:flex-row items-center">
-<div class="w-full mb-10">
-<h2 class="text-3xl font-bold mb-6">Our Commitment to Sustainability</h2>
-<p class="text-gray-600 mb-6">At Eco Print Innovations, we’re not just focused on high quality prints we’re building a business that puts the planet first. From how we power our workspace to how we package and ship our products, sustainability shapes every part of what we do.</p>
-<p class="text-gray-600 mb-6">Learn more about our values.</p>
-<div class="space-y-4">
-<div class="flex items-start gap-4">
-<div class="bg-green-100 p-3 rounded-full mt-1">
-<i class="fas fa-bolt text-green-600" aria-hidden="true"></i>
-</div>
-<div>
-<h4 class="font-semibold">Greener Energy, Smarter Printing</h4>
-<p class="text-gray-600">Our operations run on electricity from a supplier committed to renewable energy. It’s a conscious choice that supports the transition to a lower carbon future.</p>
-</div>
-</div>
-<div class="flex items-start gap-4">
-<div class="bg-green-100 p-3 rounded-full mt-1">
-<i class="fas fa-recycle text-green-600" aria-hidden="true"></i>
-</div>
-<div>
-<h4 class="font-semibold">Minimal Waste, Maximum Reuse</h4>
-<p class="text-gray-600">Around 95% of our printing waste is recycled or reused. We prioritise a closed loop approach keeping materials in use and waste to a minimum.</p>
-</div>
-</div>
-<div class="flex items-start gap-4">
-<div class="bg-green-100 p-3 rounded-full mt-1">
-<i class="fas fa-seedling text-green-600" aria-hidden="true"></i>
-</div>
-<div>
-<h4 class="font-semibold">Eco-Friendly Packaging &amp; Delivery</h4>
-<p class="text-gray-600">All of our packaging is either repurposed or reusable, giving materials a second life and cutting out unnecessary waste. We also favour low emission delivery services that share our drive to reduce waste and environmental impact. Every order is carbon offset to help balance out what can’t be avoided.</p>
-</div>
-</div>
-</div>
-</div>
-<div class="md:w-1/2 relative">
-<div class="bg-green-600 rounded-xl p-6 text-white shadow-lg floating">
-<h3 class="text-xl font-bold mb-4">Our Impact in 2024</h3>
-<div class="grid grid-cols-2 gap-4">
-<div class="bg-green-700 p-4 rounded-lg">
-<p class="text-3xl font-bold mb-1">0.5T </p>
-<p class="text-sm">Plastic waste diverted</p>
-</div>
-<div class="bg-green-700 p-4 rounded-lg">
-<p class="text-3xl font-bold mb-1">30%</p>
-<p class="text-sm">Less energy used</p>
-</div>
-<div class="bg-green-700 p-4 rounded-lg">
-<p class="text-3xl font-bold mb-1">1000+</p>
-<p class="text-sm">Happy clients</p>
-</div>
-<div class="bg-green-700 p-4 rounded-lg">
-<p class="text-3xl font-bold mb-1">1K+</p>
-<p class="text-sm">Trees planted</p>
-</div>
-</div>
-</div>
-<img alt="Our team" class="rounded-xl shadow-lg mt-6 mx-auto w-3/4 md:w-2/3 lg:w-1/2" src="https://ecoprintinnovations.github.io/ecoprintinnovations.co.uk/images/Sustainability_at_the_Core.jpg"/>
-</div>
-</div>
-</div>
+<section class="py-16" id="about">
+  <div class="container mx-auto px-4">
+    <div class="bg-green-50 rounded-2xl shadow-md p-8">
+      <div class="grid md:grid-cols-2 gap-12 items-start">
+        <div>
+          <h2 class="text-3xl font-bold mb-6">Our Commitment to Sustainability</h2>
+          <p class="text-gray-600 mb-6">At Eco Print Innovations, we’re not just focused on high quality prints we’re building a business that puts the planet first. From how we power our workspace to how we package and ship our products, sustainability shapes every part of what we do.</p>
+          <p class="text-gray-600 mb-6">Learn more about our values.</p>
+          <div class="space-y-4">
+            <div class="flex items-start gap-4">
+              <div class="bg-green-100 p-4 rounded-full mt-1">
+                <i class="fas fa-bolt text-green-600 text-2xl" aria-hidden="true"></i>
+              </div>
+              <div>
+                <h4 class="text-lg font-bold">Greener Energy, Smarter Printing</h4>
+                <p class="text-gray-600">Our operations run on electricity from a supplier committed to renewable energy. It’s a conscious choice that supports the transition to a lower carbon future.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-4">
+              <div class="bg-green-200 p-4 rounded-full mt-1">
+                <i class="fas fa-recycle text-green-600 text-2xl" aria-hidden="true"></i>
+              </div>
+              <div>
+                <h4 class="text-lg font-bold">Minimal Waste, Maximum Reuse</h4>
+                <p class="text-gray-600">Around 95% of our printing waste is recycled or reused. We prioritise a closed loop approach keeping materials in use and waste to a minimum.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-4">
+              <div class="bg-green-100 p-4 rounded-full mt-1">
+                <i class="fas fa-seedling text-green-600 text-2xl" aria-hidden="true"></i>
+              </div>
+              <div>
+                <h4 class="text-lg font-bold">Eco-Friendly Packaging &amp; Delivery</h4>
+                <p class="text-gray-600">All of our packaging is either repurposed or reusable, giving materials a second life and cutting out unnecessary waste. We also favour low emission delivery services that share our drive to reduce waste and environmental impact. Every order is carbon offset to help balance out what can’t be avoided.</p>
+              </div>
+            </div>
+          </div>
+          <p class="text-gray-700 mt-6">Every order helps reduce waste and build a greener future. <a href="/sustainability-policy.html" class="text-green-600 underline">See Our Sustainability Policy</a></p>
+        </div>
+        <div class="flex flex-col items-center">
+          <div class="bg-green-600 rounded-xl p-6 text-white shadow-lg floating mb-8 w-full">
+            <h3 class="text-xl font-bold mb-4 text-center">Our Impact in 2024</h3>
+            <div class="grid grid-cols-2 gap-4">
+              <div class="bg-green-700 p-4 rounded-lg flex items-center gap-2">
+                <i class="fas fa-recycle text-white text-xl" aria-hidden="true"></i>
+                <div>
+                  <p class="text-3xl font-bold mb-1">0.5T</p>
+                  <p class="text-sm">Plastic waste diverted</p>
+                </div>
+              </div>
+              <div class="bg-green-700 p-4 rounded-lg flex items-center gap-2">
+                <i class="fas fa-bolt text-white text-xl" aria-hidden="true"></i>
+                <div>
+                  <p class="text-3xl font-bold mb-1">30%</p>
+                  <p class="text-sm">Less energy used</p>
+                </div>
+              </div>
+              <div class="bg-green-700 p-4 rounded-lg flex items-center gap-2">
+                <i class="fas fa-smile text-white text-xl" aria-hidden="true"></i>
+                <div>
+                  <p class="text-3xl font-bold mb-1">1000+</p>
+                  <p class="text-sm">Happy clients</p>
+                </div>
+              </div>
+              <div class="bg-green-700 p-4 rounded-lg flex items-center gap-2">
+                <i class="fas fa-tree text-white text-xl" aria-hidden="true"></i>
+                <div>
+                  <p class="text-3xl font-bold mb-1">1K+</p>
+                  <p class="text-sm">Trees planted</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <img alt="Our team" class="rounded-xl shadow-lg w-full md:w-3/4" src="https://ecoprintinnovations.github.io/ecoprintinnovations.co.uk/images/Sustainability_at_the_Core.jpg"/>
+        </div>
+      </div>
+    </div>
+  </div>
 </section>
 <section class="py-16 bg-green-600 text-white">
 <div class="container mx-auto px-4 text-center">


### PR DESCRIPTION
## Summary
- Rework sustainability section into responsive two-column grid with light green backdrop
- Enlarge and style value icons with alternating backgrounds and bold headings
- Add icon-enhanced stats block and closing sustainability-policy link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a650616148832e9eeb7fe1599f318d