### PR TITLE
Fix email capture on contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -150,10 +150,11 @@
 <label class="block text-gray-700 mb-2" for="name">Your Name</label>
 <input class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500" id="name" name="name" type="text"/>
 </div>
-<div class="mb-4">
-<label class="block text-gray-700 mb-2" for="email">Email Address</label>
-<input class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500" id="email" name="_replyto" type="email"/>
-</div>
+        <div class="mb-4">
+          <label class="block text-gray-700 mb-2" for="email">Email Address</label>
+          <input class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500" id="email" name="email" type="email"/>
+          <input type="hidden" id="reply-to" name="_replyto"/>
+        </div>
 <div class="mb-4">
 <label class="block text-gray-700 mb-2" for="phone">Phone Number</label>
 <input class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500" id="phone" name="phone" type="tel"/>
@@ -277,6 +278,19 @@
     if (nextField) {
       const base = nextField.value.split('?')[0];
       nextField.value = `${base}?request_id=${encodeURIComponent(id)}`;
+    }
+    const emailField = document.getElementById('email');
+    const replyToField = document.getElementById('reply-to');
+    if (emailField && replyToField) {
+      const syncReplyTo = () => {
+        replyToField.value = emailField.value.trim();
+      };
+      emailField.addEventListener('input', syncReplyTo);
+      const form = document.getElementById('contact-form');
+      if (form) {
+        form.addEventListener('submit', syncReplyTo);
+      }
+      syncReplyTo();
     }
   });
 </script>


### PR DESCRIPTION
## Summary
- ensure the contact form submits the visitor's email address by naming the field `email`
- synchronize a hidden `_replyto` field from the visible email input so FormSubmit continues to set the reply-to header

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c939986940832e99ec5946e2a95802